### PR TITLE
Moved BTC Logo in vertical

### DIFF
--- a/btcticker.py
+++ b/btcticker.py
@@ -149,7 +149,7 @@ def updateDisplay(config,pricestack):
             draw.text((110,95),str("%+d" % round((pricestack[-1]-pricestack[1])/pricestack[-1]*100,2))+"%",font =font_date,fill = 0)
             draw.text((5,200),"$"+format(int(round(BTC)),","),font =font,fill = 0)
             draw.text((0,10),str(time.strftime("%c")),font =font_date,fill = 0)
-            image.paste(bmp, (10,20))
+            image.paste(bmp, (10,25))
             image.paste(bmp2,(10,125))
             if config['display']['orientation'] == 180 :
                 image=image.rotate(180, expand=True)


### PR DESCRIPTION
BTC Logo in vertical mode clipped the text by a couple pixels. Moved it down by 5.

![image](https://user-images.githubusercontent.com/22281131/100893035-d4909400-34b2-11eb-9051-cd22a14f942c.png)

Image above shows before the change where it was clipped. Apologies for the low res shot.