### PR TITLE
Fixes #77 Close the fig subplot to prevent memory leak warning message from matplotlib

### DIFF
--- a/btcticker.py
+++ b/btcticker.py
@@ -209,6 +209,7 @@ def makeSpark(pricestack):
     imgspk = Image.open(os.path.join(picdir,'spark.png'))
     file_out = os.path.join(picdir,'spark.bmp')
     imgspk.save(file_out)
+    plt.close(fig)
     plt.cla() # Close plot to prevent memory error
     ax.cla() # Close axis to prevent memory error
     imgspk.close()


### PR DESCRIPTION
I just tried it locally (on Ubuntu) and this warning message disappeared
`python3[530]: /home/pi/btcticker/btcticker.py:197: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).`

It would be good if someone tests it on a Raspberry Pi with a Waveshare display. I can't do it right now because I don't have that setup at the moment.